### PR TITLE
Support Historical API Endpoint

### DIFF
--- a/openexchangerates/__init__.py
+++ b/openexchangerates/__init__.py
@@ -20,6 +20,7 @@ class OpenExchangeRatesClient(object):
     BASE_URL = 'http://openexchangerates.org/api'
     ENDPOINT_LATEST = BASE_URL + '/latest.json'
     ENDPOINT_CURRENCIES = BASE_URL + '/currencies.json'
+    ENDPOINT_HISTORICAL = BASE_URL + '/historical/%s.json'
 
     def __init__(self, api_key):
         """Convenient constructor"""
@@ -78,3 +79,32 @@ class OpenExchangeRatesClient(object):
             raise OpenExchangeRatesClientException(e)
 
         return resp.json()
+
+    def historical(self, date, base='USD'):
+        """Fetches historical exchange rate data from service
+
+        :Example Data:
+            {
+                disclaimer: "<Disclaimer data>",
+                license: "<License data>",
+                timestamp: 1358150409,
+                base: "USD",
+                rates: {
+                    AED: 3.666311,
+                    AFN: 51.2281,
+                    ALL: 104.748751,
+                    AMD: 406.919999,
+                    ANG: 1.7831,
+                    ...
+                }
+            }
+        """
+        try:
+            resp = self.client.get(self.ENDPOINT_HISTORICAL %
+                                   date.strftime("%Y-%m-%d"),
+                                   params={'base': base})
+            resp.raise_for_status()
+        except requests.exceptions.RequestException, e:
+            raise OpenExchangeRatesClientException(e)
+        return resp.json(parse_int=decimal.Decimal,
+                         parse_float=decimal.Decimal)

--- a/openexchangerates/tests.py
+++ b/openexchangerates/tests.py
@@ -5,6 +5,7 @@ from httpretty import HTTPretty, httprettified
 
 import openexchangerates
 
+from datetime import date as Date
 
 class TestOpenExchangeRates(unittest.TestCase):
 
@@ -27,6 +28,38 @@ class TestOpenExchangeRates(unittest.TestCase):
     }
 }
 """
+
+    _FIXTURE_HISTORICAL = """{
+    "disclaimer": "<Disclaimer data>",
+    "license": "<License data>",
+    "timestamp": 1358150409,
+    "base": "USD",
+    "rates": {
+        "AED": 3.666311,
+        "AFN": 51.2281,
+        "ALL": 104.748751
+    }
+}
+"""
+
+    @httprettified
+    def test_historical(self):
+        """Tests openexchangerates.OpenExchangeRateClient.historical``"""
+        client = openexchangerates.OpenExchangeRatesClient('DUMMY_API_KEY')
+        date = Date.fromtimestamp(1358150409)
+        HTTPretty.register_uri(HTTPretty.GET, client.ENDPOINT_HISTORICAL %
+                               date.strftime("%Y-%m-%d"),
+                               body=self._FIXTURE_LATEST)
+        historical = client.historical(date)
+        self.assertIn('rates', historical)
+        rates = historical['rates']
+        self.assertEqual(len(rates), 3)
+        self.assertIn('AED', rates)
+        self.assertEqual(rates['AED'], Decimal('3.666311'))
+        self.assertIn('AFN', rates)
+        self.assertEqual(rates['AFN'], Decimal('51.2281'))
+        self.assertIn('ALL', rates)
+        self.assertEqual(rates['ALL'], Decimal('104.748751'))
 
     @httprettified
     def test_currencies(self):


### PR DESCRIPTION
Previously there was no support for the historical endpoint.
Given a datetime.date object (and optionally a currency base) this
method will fetch the exchange rates for the specified date.
The tests are updates to cover this new method.