### PR TITLE
Option to apply base conversion on client side for free API plan

### DIFF
--- a/openexchangerates/__init__.py
+++ b/openexchangerates/__init__.py
@@ -49,7 +49,7 @@ class OpenExchangeRatesClient(object):
         try:
             resp = self.client.get(self.ENDPOINT_LATEST, params={'base': base})
             resp.raise_for_status()
-        except requests.exceptions.RequestException, e:
+        except requests.exceptions.RequestException as e:
             raise OpenExchangeRatesClientException(e)
         return resp.json(parse_int=decimal.Decimal,
                          parse_float=decimal.Decimal)
@@ -75,7 +75,7 @@ class OpenExchangeRatesClient(object):
         """
         try:
             resp = self.client.get(self.ENDPOINT_CURRENCIES)
-        except requests.exceptions.RequestException, e:
+        except requests.exceptions.RequestException as e:
             raise OpenExchangeRatesClientException(e)
 
         return resp.json()
@@ -104,7 +104,7 @@ class OpenExchangeRatesClient(object):
                                    date.strftime("%Y-%m-%d"),
                                    params={'base': base})
             resp.raise_for_status()
-        except requests.exceptions.RequestException, e:
+        except requests.exceptions.RequestException as e:
             raise OpenExchangeRatesClientException(e)
         return resp.json(parse_int=decimal.Decimal,
                          parse_float=decimal.Decimal)

--- a/openexchangerates/tests.py
+++ b/openexchangerates/tests.py
@@ -12,7 +12,8 @@ class TestOpenExchangeRates(unittest.TestCase):
     _FIXTURE_CURRENCIES = """{
     "AED": "United Arab Emirates Dirham",
     "AFN": "Afghan Afghani",
-    "ALL": "Albanian Lek"
+    "ALL": "Albanian Lek",
+    "USD": "United States Dollar"
 }
 """
 
@@ -24,7 +25,8 @@ class TestOpenExchangeRates(unittest.TestCase):
     "rates": {
         "AED": 3.666311,
         "AFN": 51.2281,
-        "ALL": 104.748751
+        "ALL": 104.748751,
+        "USD": 1
     }
 }
 """
@@ -37,7 +39,8 @@ class TestOpenExchangeRates(unittest.TestCase):
     "rates": {
         "AED": 3.666311,
         "AFN": 51.2281,
-        "ALL": 104.748751
+        "ALL": 104.748751,
+        "USD": 1
     }
 }
 """
@@ -53,13 +56,15 @@ class TestOpenExchangeRates(unittest.TestCase):
         historical = client.historical(date)
         self.assertIn('rates', historical)
         rates = historical['rates']
-        self.assertEqual(len(rates), 3)
+        self.assertEqual(len(rates), 4)
         self.assertIn('AED', rates)
         self.assertEqual(rates['AED'], Decimal('3.666311'))
         self.assertIn('AFN', rates)
         self.assertEqual(rates['AFN'], Decimal('51.2281'))
         self.assertIn('ALL', rates)
         self.assertEqual(rates['ALL'], Decimal('104.748751'))
+        self.assertIn('USD', rates)
+        self.assertEqual(rates['USD'], Decimal('1'))
 
     @httprettified
     def test_currencies(self):
@@ -68,10 +73,11 @@ class TestOpenExchangeRates(unittest.TestCase):
         HTTPretty.register_uri(HTTPretty.GET, client.ENDPOINT_CURRENCIES,
                                body=self._FIXTURE_CURRENCIES)
         currencies = client.currencies()
-        self.assertEqual(len(currencies), 3)
+        self.assertEqual(len(currencies), 4)
         self.assertIn('AED', currencies)
         self.assertIn('AFN', currencies)
         self.assertIn('ALL', currencies)
+        self.assertIn('USD', currencies)
 
     @httprettified
     def test_latest(self):
@@ -82,13 +88,42 @@ class TestOpenExchangeRates(unittest.TestCase):
         latest = client.latest()
         self.assertIn('rates', latest)
         rates = latest['rates']
-        self.assertEqual(len(rates), 3)
+        self.assertEqual(len(rates), 4)
         self.assertIn('AED', rates)
         self.assertEqual(rates['AED'], Decimal('3.666311'))
         self.assertIn('AFN', rates)
         self.assertEqual(rates['AFN'], Decimal('51.2281'))
         self.assertIn('ALL', rates)
         self.assertEqual(rates['ALL'], Decimal('104.748751'))
+        self.assertIn('USD', rates)
+        self.assertEqual(rates['USD'], Decimal('1'))
+
+
+    @httprettified
+    def test_latest_with_local_base_conversion(self):
+        client = openexchangerates.OpenExchangeRatesClient('DUMMY_API_KEY')
+        HTTPretty.register_uri(HTTPretty.GET, client.ENDPOINT_LATEST,
+                               body=self._FIXTURE_LATEST)
+        rates = client.latest(local_base='AED')['rates']
+        self.assertEqual(rates['AED'], Decimal('1'))
+        self.assertEqual(rates['AFN'], Decimal('13.97265535'))
+        self.assertEqual(rates['ALL'], Decimal('28.57061253'))
+        self.assertEqual(rates['USD'], Decimal('0.27275373'))
+
+
+    @httprettified
+    def test_historical_with_local_base_conversion(self):
+        client = openexchangerates.OpenExchangeRatesClient('DUMMY_API_KEY')
+        date = Date.fromtimestamp(1358150409)
+        HTTPretty.register_uri(HTTPretty.GET, client.ENDPOINT_HISTORICAL %
+                               date.strftime("%Y-%m-%d"),
+                               body=self._FIXTURE_HISTORICAL)
+        rates = client.historical(date, local_base='AED')['rates']
+        self.assertEqual(rates['AED'], Decimal('1'))
+        self.assertEqual(rates['AFN'], Decimal('13.97265535'))
+        self.assertEqual(rates['ALL'], Decimal('28.57061253'))
+        self.assertEqual(rates['USD'], Decimal('0.27275373'))
+
 
     @httprettified
     def test_exception(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six


### PR DESCRIPTION
This allows to overcome the limitation of not being able to change the base currency on API requests when using the free plan.